### PR TITLE
from future is supposed to be at the very top of env.py, noted

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,4 +1,3 @@
-import os
 from __future__ import with_statement
 
 import logging
@@ -7,6 +6,7 @@ from logging.config import fileConfig
 from flask import current_app
 
 from alembic import context
+import os
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
syntax changes